### PR TITLE
Add psd test / normest

### DIFF
--- a/src/JOLI.jl
+++ b/src/JOLI.jl
@@ -85,7 +85,8 @@ import IterativeSolvers.Adivtype
 
 # extra exported methods
 export deltype, reltype
-export elements, hasinverse, issquare, istall, iswide, iscomplex, islinear, isadjoint, isequiv
+export elements, hasinverse, issquare, istall, iswide, iscomplex, islinear, isadjoint, isequiv,
+	   isposdef, normest
 
 # local array unions for serial operators
 const LocalVector{T}=Union{Vector{T},SubArray{T,1,dA},

--- a/src/joAbstractLinearOperator/extra_functions.jl
+++ b/src/joAbstractLinearOperator/extra_functions.jl
@@ -35,17 +35,16 @@ function normest(A::joAbstractLinearOperator{DDT,RDT};numiters::Integer=5,tol::F
     spec_norm_aprox = 0
 
     u_hat = DDT<:Real ? jo_convert(DDT,randn(A.m)) : jo_convert(DDT,complex.(randn(A.m),randn(A.m)))
-    u_hat  = u_hat / norm(u_hat,2)
-    v_hat  = deepcopy(u_hat)
+    mul!(u_hat,u_hat,1/norm(u_hat,2)) 
+    v_hat = deepcopy(u_hat)
     for i=1:numiters
-        result_u = A'*u_hat
-        v_hat    = result_u / norm(result_u,2)
+        v_hat = A'*u_hat
+        mul!(v_hat,v_hat,1/norm(v_hat,2)) 
       
-        result_v = A*v_hat
-        u_hat    = result_v / norm(result_v,2)
-
-        spec_norm_aprox = u_hat'*(A*v_hat)
+        u_hat = A*v_hat
+        mul!(u_hat,u_hat,1/norm(u_hat,2))      
     end
+    spec_norm_aprox = u_hat'*(A*v_hat)
     return spec_norm_aprox
 end
 

--- a/test/test_extra_functions.jl
+++ b/test/test_extra_functions.jl
@@ -1,0 +1,50 @@
+# Unit tests for extra joli functions
+# Rafael Orozco (rorozco@gatech.edu)
+# July 2021
+
+using JOLI, Test, LinearAlgebra
+
+################################################# test isposdef ####################################################
+
+@testset "Extra Functions Unit Tests" begin
+
+    # set up operator that should be posdef
+    A = [1.0 0.0;
+         0.0 1.0]
+    jo_A = joMatrix(A);
+    @test isequal(JOLI.isposdef(jo_A)[1], true)
+
+    # set up operator that is a complex matrix but posdef 
+    k = 4
+    B = complex.(randn(k,k),randn(k,k))
+    A = B*B'
+    jo_A = joMatrix(A);
+    @test isequal(JOLI.isposdef(jo_A)[1], true)
+
+    # set up operator that should NOT be posdef
+    A = [-1.0 0.0;
+         0.0 -1.0]
+    jo_A = joMatrix(A);
+    @test isequal(JOLI.isposdef(jo_A)[1], false)
+
+    # set up operator that should NOT be posdef because of imaginary result. 
+    k = 4
+    A = complex.(randn(k,k),randn(k,k))
+    jo_A = joMatrix(A);
+    @test isequal(JOLI.isposdef(jo_A)[1], false)
+
+
+#################################################### test normest ###################################################
+
+    # set up operator and compare with opnorm()
+    A = [1.0 0.0;
+         0.0 1.0]
+    jo_A = joMatrix(A);
+    @test isapprox(normest(jo_A), opnorm(A))
+
+    A = randn(5,5)
+    jo_A = joMatrix(A);
+    @test isapprox(normest(jo_A), opnorm(A);atol=1e-2)
+   
+
+end

--- a/test/test_extra_functions.jl
+++ b/test/test_extra_functions.jl
@@ -44,7 +44,7 @@ using JOLI, Test, LinearAlgebra
 
     A = randn(5,5)
     jo_A = joMatrix(A);
-    @test isapprox(normest(jo_A), opnorm(A);atol=1e-2)
+    @test isapprox(normest(jo_A), opnorm(A);atol=1e-1)
    
 
 end

--- a/test/test_extra_functions.jl
+++ b/test/test_extra_functions.jl
@@ -12,26 +12,26 @@ using JOLI, Test, LinearAlgebra
     A = [1.0 0.0;
          0.0 1.0]
     jo_A = joMatrix(A);
-    @test isequal(JOLI.isposdef(jo_A)[1], true)
+    @test JOLI.isposdef(jo_A)[1]
 
     # set up operator that is a complex matrix but posdef 
     k = 4
     B = complex.(randn(k,k),randn(k,k))
     A = B*B'
     jo_A = joMatrix(A);
-    @test isequal(JOLI.isposdef(jo_A)[1], true)
+    @test JOLI.isposdef(jo_A)[1]
 
     # set up operator that should NOT be posdef
     A = [-1.0 0.0;
          0.0 -1.0]
     jo_A = joMatrix(A);
-    @test isequal(JOLI.isposdef(jo_A)[1], false)
+    @test !JOLI.isposdef(jo_A)[1]
 
     # set up operator that should NOT be posdef because of imaginary result. 
     k = 4
     A = complex.(randn(k,k),randn(k,k))
     jo_A = joMatrix(A);
-    @test isequal(JOLI.isposdef(jo_A)[1], false)
+    @test !JOLI.isposdef(jo_A)[1]
 
 
 #################################################### test normest ###################################################
@@ -45,6 +45,11 @@ using JOLI, Test, LinearAlgebra
     A = randn(5,5)
     jo_A = joMatrix(A);
     @test isapprox(normest(jo_A), opnorm(A);atol=1e-1)
+
+    #more iterations should make the approximation better
+    A = randn(5,5)
+    jo_A = joMatrix(A);
+    @test isapprox(normest(jo_A; numiters=20), opnorm(A);atol=1e-3)
    
 
 end


### PR DESCRIPTION
Added two functions to extra_functions.jl
1.) isposdef() to check for positive (or semi) definitiveness 
2.) normest() to return an approximation to the spectral operator norm.

Added test_extra_functions.jl with some sanity checks on the two new functions. 