### PR TITLE
use `reverse` to replace deprecated `flipdim`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JOLI"
 uuid = "bb331ad6-a1cf-11e9-23da-9bcb53c69f6f"
 authors = ["Henryk Modzelewski <henryk_modzelewski@mac.com>"]
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/joLinearFunctionConstructors/joExtend.jl
+++ b/src/joLinearFunctionConstructors/joExtend.jl
@@ -47,7 +47,7 @@ module joExtend_etc
         return jo_convert(rdt,w,false)
     end
     function mirror_fwd(v::LocalMatrix{VT},n::Integer,pad_upper::Integer,pad_lower::Integer,rdt=DataType) where {VT<:Number}
-        w = [flipdim(v[1:pad_lower,:],1); v; flipdim(v[end-pad_upper+1:end,:],1)]
+        w = [reverse(v[1:pad_lower,:],dims=1); v; reverse(v[end-pad_upper+1:end,:],dims=1)]
         return jo_convert(rdt,w,false)
     end
     function mirror_tran(v::LocalVector{VT},n::Integer,pad_upper::Integer,pad_lower::Integer,rdt=DataType) where {VT<:Number}
@@ -58,8 +58,8 @@ module joExtend_etc
     end
     function mirror_tran(v::LocalMatrix{VT},n::Integer,pad_upper::Integer,pad_lower::Integer,rdt=DataType) where {VT<:Number}
         w = v[pad_lower+1:end-pad_upper,:]
-        w[1:pad_lower,:] += flipdim(v[1:pad_lower,:],1)
-        w[end-pad_upper+1:end,:] += flipdim(v[end-pad_upper+1:end,:],1)
+        w[1:pad_lower,:] += reverse(v[1:pad_lower,:],dims=1)
+        w[end-pad_upper+1:end,:] += reverse(v[end-pad_upper+1:end,:],dims=1)
         return jo_convert(rdt,w,false)
     end
     ### periodic
@@ -186,4 +186,3 @@ function joExtend(n::Integer,pad_type::Symbol;
     end
     return nothing
 end
-

--- a/test/test_joExtend.jl
+++ b/test/test_joExtend.jl
@@ -13,14 +13,12 @@ for t=1:T # start test loop
 
     verbose && println("$tsname ($n,$l,$u)")
     @testset "$n x $m" begin
-        @test isadjoint(Az)[1]
-        @test isadjoint(Ab)[1]
-        @test isadjoint(Am)[1]
-        @test isadjoint(Ap)[1]
-        @test islinear(Az)[1]
-        @test islinear(Ab)[1]
-        @test islinear(Am)[1]
-        @test islinear(Ap)[1]
+        for A ∈ [Az, Ab, Am, Ap]
+            @test isadjoint(A)[1]
+            @test islinear(A)[1]
+            v = randn(size(A, 2))
+            @test A * v == vec(A * reshape(v, :, 1))
+        end
     end
     
 end # end test loop


### PR DESCRIPTION
`flipdim` already deprecated so changed it to `reverse`