### PR TITLE
Prepare split of `AbstractQ` and `AbstractMatrix`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JOLI"
 uuid = "bb331ad6-a1cf-11e9-23da-9bcb53c69f6f"
 authors = ["Henryk Modzelewski <henryk_modzelewski@mac.com>"]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/JOLI.jl
+++ b/src/JOLI.jl
@@ -74,7 +74,7 @@ import Base.getindex
 
 
 # what's imported from LinearAlgebra
-import LinearAlgebra.norm
+import LinearAlgebra.norm, LinearAlgebra.AbstractQ
 import LinearAlgebra.issymmetric, LinearAlgebra.ishermitian
 import LinearAlgebra.mul!, LinearAlgebra.ldiv!
 

--- a/src/joAbstractDAparallelLinearOperator/constructors.jl
+++ b/src/joAbstractDAparallelLinearOperator/constructors.jl
@@ -35,7 +35,7 @@ Create a linear operator working on 2D DArray in multi-vector (over 2nd dimensio
 
 """
 function joDAdistributedLinOp(A::joAbstractLinearOperator{DDT,RDT},psin::joPAsetup,
-        fclean::Bool=false,rclean::Bool=false) where {DDT<:Number,RDT<:Number,INT<:Integer}
+        fclean::Bool=false,rclean::Bool=false) where {DDT<:Number,RDT<:Number}
 
     psin.chunks[1]==1 || throw(joDAdistributedLinearOperatorException("joDAdistributedLinearOperator: invalid joPAsetup - must not be distributed in 1st dimension"))
     A.n==psin.dims[1]  || throw(joDAdistributedLinearOperatorException("joDAdistributedLinearOperator: invalid joPAsetup - 1st dimension off joPAsetup does not match size(A,2)"))

--- a/src/joAbstractLinearOperator/constructors.jl
+++ b/src/joAbstractLinearOperator/constructors.jl
@@ -8,7 +8,7 @@
 """
 joMatrix outer constructor
 
-    joMatrix(array::AbstractMatrix;
+    joMatrix(array::Union{AbstractMatrix,AbstractQ};
              DDT::DataType=eltype(array),
              RDT::DataType=promote_type(eltype(array),DDT),
              name::String="joMatrix")
@@ -26,7 +26,7 @@ Look up argument names in help to joMatrix type.
 - if RDT:<Real for complex matrix then imaginary part will be neglected for forward/conjugate operator
 
 """
-function joMatrix(array::AbstractMatrix{EDT};
+function joMatrix(array::Union{AbstractMatrix{EDT},AbstractQ{EDT}};
     DDT::DataType=EDT,RDT::DataType=promote_type(EDT,DDT),name::String="joMatrix") where {EDT}
 
         (typeof(array)<:DArray || typeof(array)<:SharedArray) && @warn "Creating joMatrix from non-local array like $(typeof(array)) is likely going to have adverse impact on JOLI's health. Please, avoid it."

--- a/src/joAbstractSAparallelLinearOperator/constructors.jl
+++ b/src/joAbstractSAparallelLinearOperator/constructors.jl
@@ -35,7 +35,7 @@ Create a linear operator working on 2D SharedArray in multi-vector (over 2nd dim
 
 """
 function joSAdistributedLinOp(A::joAbstractLinearOperator{DDT,RDT},psin::joPAsetup,
-        fclean::Bool=false,rclean::Bool=false) where {DDT<:Number,RDT<:Number,INT<:Integer}
+        fclean::Bool=false,rclean::Bool=false) where {DDT<:Number,RDT<:Number}
 
     psin.chunks[1]==1 || throw(joSAdistributedLinearOperatorException("joSAdistributedLinearOperator: invalid joPAsetup - must not be distributed in 1st dimension"))
     A.n==psin.dims[1]  || throw(joSAdistributedLinearOperatorException("joSAdistributedLinearOperator: invalid joPAsetup - 1st dimension off joPAsetup does not match size(A,2)"))

--- a/src/joMiscTypesMethods/joPAsetup.jl
+++ b/src/joMiscTypesMethods/joPAsetup.jl
@@ -146,8 +146,7 @@ Creates joPAsetup type - basic 1D distribution
 """
 function joPAsetup(wpool::WorkerPool,n::Integer;
         DT::DataType=joFloat,
-        name::String="joPAsetup",
-        ) where INT<:Integer
+        name::String="joPAsetup")
     n>0 || throw(joPAsetupException("joPAsetup: invalid lenght of the vector: $n"))
     dims=(n,)
     chunks=joPAsetup_etc.default_chunks(dims,sort(workers(wpool)))


### PR DESCRIPTION
This prepares the ground for https://github.com/JuliaLang/julia/pull/46196. Along the way, I fixed a few unbound type vars.